### PR TITLE
Update workflow for latest tag

### DIFF
--- a/.github/workflows/update-drawio-submodule.yml
+++ b/.github/workflows/update-drawio-submodule.yml
@@ -1,0 +1,42 @@
+name: Update draw.io submodule
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Ensure vendor directory
+        run: |
+          mkdir -p vendor
+
+      - name: Add or update drawio submodule to latest tag
+        run: |
+          latest_tag=$(git -c versionsort.suffix=- ls-remote --tags --refs https://github.com/jgraph/drawio \
+            | cut -d/ -f3 | sort -V | tail -n1)
+          if [ ! -d vendor/drawio ]; then
+            git submodule add https://github.com/jgraph/drawio vendor/drawio
+          fi
+          cd vendor/drawio
+          git fetch --tags
+          git checkout "$latest_tag"
+          cd ../..
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .gitmodules vendor/drawio
+          git commit -m "Update draw.io submodule" || echo "No changes to commit"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Provides packaging for the [draw.io](https://www.draw.io) diagramming library. T
 * Project Lead: [Marius Dumitru Florea](http://www.xwiki.org/xwiki/bin/view/XWiki/mflorea)
 * License: **Apache 2.0** license. Note that the packaged code (the draw.io library developed by JGraph Ltd) and some classes we modified (also developed by JGraph Ltd)  are licensed under Apache 2.0.
 * Continuous Integration Status: [![Build Status](http://ci.xwiki.org/job/XWiki%20Contrib/job/draw.io/job/master/badge/icon)](http://ci.xwiki.org/view/Contrib/job/XWiki%20Contrib/job/draw.io/job/master/)
+
+## Vendor submodule
+
+The `vendor` directory stores [jgraph/drawio](https://github.com/jgraph/drawio) as a Git submodule.
+A manual GitHub Actions workflow (`update-drawio-submodule.yml`) can be triggered
+from the **Actions** tab to add or update this submodule. The workflow creates
+the `vendor` folder if needed, adds the submodule when missing and checks out
+the latest available tag of the draw.io repository each time it runs, committing
+the change automatically.


### PR DESCRIPTION
## Summary
- update draw.io submodule workflow to always checkout the latest tag
- clarify README about using the latest tag

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b9e5857408321ae7f52b164c38cdb