### PR TITLE
Add deployment workflow and update DrawIO configuration

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy DrawIO WebJAR
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Build and deploy to GitHub Packages
+      run: |
+        mvn deploy -s .github/maven-settings.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/draw.io-webjar/pom.xml
+++ b/draw.io-webjar/pom.xml
@@ -27,7 +27,9 @@
     <artifactId>draw.io-parent</artifactId>
     <version>24.5.5-4-SNAPSHOT</version>
   </parent>
-  <artifactId>draw.io</artifactId>
+  <groupId>de.seclution.xwiki</groupId>
+  <artifactId>drawio-webjar</artifactId>
+  <version>22.0.3</version>
   <packaging>webjar</packaging>
   <name>draw.io WebJar</name>
   <description>Provides WebJar packaging for the draw.io JavaScript diagramming library.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>24.5.5</draw.io.version>
+    <draw.io.version>22.0.3</draw.io.version>
     <mxgraph.version>4.2.2_final</mxgraph.version>
     <draw.io-gliffy.version>13.4.8</draw.io-gliffy.version>
     <!-- The path to the folder where we unpack the draw.io sources. -->


### PR DESCRIPTION
## Summary
- update draw.io version in parent POM
- configure webjar module coordinates for publishing
- add GitHub Actions workflow for deploying to GitHub Packages
- provide Maven settings for GitHub authentication

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685ba0f2e9908321bf62ffc407ae43c0